### PR TITLE
feat: Introduce `bevy_asset_loader`

### DIFF
--- a/ryot/src/appearances/mod.rs
+++ b/ryot/src/appearances/mod.rs
@@ -1,6 +1,6 @@
 include!(concat!(env!("OUT_DIR"), "/appearances.rs"));
 
-use crate::{SpriteLayout, SpriteSheetConfig};
+use crate::{get_decompressed_file_name, SpriteLayout, SpriteSheetConfig};
 use glam::UVec2;
 use serde::{Deserialize, Serialize};
 
@@ -138,6 +138,12 @@ impl SpriteSheetSet {
     pub fn get_sprite_index_by_id(&self, sprite_id: u32) -> Option<usize> {
         self.get_by_sprite_id(sprite_id)?
             .get_sprite_index(sprite_id)
+    }
+
+    pub fn get_for_file(&self, file: &str) -> Option<&SpriteSheet> {
+        self.sprite_sheets
+            .iter()
+            .find(|sprite_sheet| get_decompressed_file_name(&sprite_sheet.file) == *file)
     }
 }
 

--- a/ryot_compass/Cargo.toml
+++ b/ryot_compass/Cargo.toml
@@ -35,6 +35,7 @@ uuid = "1.6.1"
 futures = "0.3.30"
 wasm-bindgen-futures = "0.4.40"
 bevy_common_assets = { version = "0.9.0", features = ["toml", "json"] }
+bevy_asset_loader = { version = "0.19.1", features = ["2d"] }
 thiserror = "1.0.56"
 color-eyre = "0.6.2"
 rstest = "0.18.2"
@@ -80,6 +81,8 @@ ryot = { version = "0.1.0", path = "../ryot" }
 [features]
 default = []
 lmdb = ["dep:heed"]
+pre_loaded_sprites = []
+content_rebuild_on_change = []
 
 [lints.clippy]
 enum_glob_use = "deny"

--- a/ryot_compass/assets/config/.content.toml
+++ b/ryot_compass/assets/config/.content.toml
@@ -8,6 +8,6 @@ compression_config = { compressed_header_size = 32, content_header_size = 122 }
 encoding_config = { vertically_flipped = true, reversed_r_b_channels = true }
 
 [grid]
-rows = 65535
-columns = 65535
+rows = 256
+columns = 256
 tile_size = [32,32]

--- a/ryot_compass/build_scripts/content_builder.rs
+++ b/ryot_compass/build_scripts/content_builder.rs
@@ -16,6 +16,7 @@ pub fn run() -> Result<(), std::io::Error> {
     };
 
     // Tell Cargo to rerun this build script if the config file changes
+    #[cfg(feature = "content_rebuild_on_change")]
     println!("cargo:rerun-if-changed={}", path);
 
     let content_config = read_content_configs(path);
@@ -23,12 +24,14 @@ pub fn run() -> Result<(), std::io::Error> {
     let ContentConfigs { directories, .. } = content_config.clone();
 
     // Tell Cargo to rerun this build script if our content folder changes
+    #[cfg(feature = "content_rebuild_on_change")]
     println!(
         "cargo:rerun-if-changed={}",
         directories.source_path.display()
     );
 
     // Tell Cargo to rerun this build script if our destination folder changes
+    #[cfg(feature = "content_rebuild_on_change")]
     println!(
         "cargo:rerun-if-changed={}",
         directories.destination_path.display()

--- a/ryot_compass/src/error_handling.rs
+++ b/ryot_compass/src/error_handling.rs
@@ -1,6 +1,18 @@
+use crate::AppStates;
 use bevy::app::AppExit;
 use bevy::prelude::*;
 use bevy_egui::EguiContexts;
+
+pub struct ErrorPlugin;
+
+impl Plugin for ErrorPlugin {
+    fn build(&self, app: &mut App) {
+        app.init_resource::<ErrorState>().add_systems(
+            Update,
+            (display_error_window, check_for_exit).run_if(in_state(AppStates::Ready)),
+        );
+    }
+}
 
 #[derive(Resource, Default)]
 pub struct ErrorState {
@@ -9,6 +21,7 @@ pub struct ErrorState {
     pub close_requested: bool,
 }
 
+#[allow(dead_code)]
 impl ErrorState {
     pub fn new(error_message: String) -> Self {
         Self {

--- a/ryot_compass/src/helpers/camera.rs
+++ b/ryot_compass/src/helpers/camera.rs
@@ -1,6 +1,5 @@
-use crate::{ConfigAsset, ConfigHandle, DefaultConfig};
 use bevy::{input::Input, math::Vec3, prelude::*, render::camera::Camera};
-use ryot::ContentConfigs;
+use ryot::tile_grid::TileGrid;
 
 // A simple camera system for moving and zooming the camera.
 #[allow(dead_code)]
@@ -8,8 +7,6 @@ pub fn movement(
     time: Res<Time>,
     windows: Query<&mut Window>,
     keyboard_input: Res<Input<KeyCode>>,
-    config: Res<ConfigHandle<ContentConfigs>>,
-    configs: Res<Assets<ConfigAsset<ContentConfigs>>>,
     mut query: Query<(&mut Transform, &mut OrthographicProjection), With<Camera>>,
 ) {
     for (mut transform, mut ortho) in query.iter_mut() {
@@ -56,7 +53,8 @@ pub fn movement(
             ortho.scale
         };
 
-        let tile_grid = configs.get(config.handle.id()).or_default().grid;
+        // Using default because camera doesn't work properly with smaller grids
+        let tile_grid = TileGrid::default();
 
         transform.translation.x =
             normalize_dimension(transform.translation.x, tile_grid.tile_size.x);

--- a/ryot_compass/src/lib.rs
+++ b/ryot_compass/src/lib.rs
@@ -1,8 +1,26 @@
+use crate::sprites::SpritesPlugin;
+use bevy::app::{App, AppExit, Plugin};
+use bevy::asset::AssetMetaCheck;
+use bevy::input::common_conditions::input_toggle_active;
+use bevy::prelude::*;
+use bevy::DefaultPlugins;
+use bevy_egui::EguiPlugin;
+use bevy_inspector_egui::quick::WorldInspectorPlugin;
+
+#[derive(States, Default, Clone, Eq, PartialEq, Debug, Hash)]
+pub enum AppStates {
+    #[default]
+    LoadingContent,
+    PreparingContent,
+    LoadingSprites,
+    PreparingSprites,
+    Ready,
+}
+
 pub mod item;
 
 #[cfg(all(feature = "lmdb", not(target_arch = "wasm32")))]
 pub mod lmdb;
-
 #[cfg(all(feature = "lmdb", not(target_arch = "wasm32")))]
 pub use lmdb::*;
 
@@ -33,3 +51,52 @@ pub use tileset::*;
 
 mod ui;
 pub use ui::*;
+
+pub struct AppPlugin;
+
+impl Plugin for AppPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_state::<AppStates>()
+            .add_event::<AppExit>()
+            .insert_resource(AssetMetaCheck::Never)
+            .add_plugins((
+                DefaultPlugins
+                    .set(entitled_window("Compass".to_string()))
+                    .set(ImagePlugin::default_nearest()),
+                ContentPlugin,
+                SpritesPlugin,
+                WorldInspectorPlugin::default().run_if(input_toggle_active(true, KeyCode::Escape)),
+            ))
+            .insert_resource(ClearColor(Color::rgb(0.12, 0.12, 0.12)));
+    }
+}
+
+pub fn entitled_window(title: String) -> WindowPlugin {
+    WindowPlugin {
+        primary_window: Some(Window {
+            title,
+            // Bind to canvas included in `index.html`
+            canvas: Some("#bevy".to_owned()),
+            // The canvas size is constrained in index.html and build/web/styles.css
+            fit_canvas_to_parent: true,
+            // Tells wasm not to override default event handling, like F5 and Ctrl+R
+            prevent_default_event_handling: false,
+            ..default()
+        }),
+        ..default()
+    }
+}
+
+pub trait OptionalPlugin {
+    fn add_optional_plugin<T: Plugin>(&mut self, plugin: T) -> &mut Self;
+}
+
+impl OptionalPlugin for App {
+    fn add_optional_plugin<T: Plugin>(&mut self, plugin: T) -> &mut Self {
+        if !self.is_plugin_added::<EguiPlugin>() {
+            self.add_plugins(plugin);
+        }
+
+        self
+    }
+}

--- a/ryot_compass/src/minimap/mod.rs
+++ b/ryot_compass/src/minimap/mod.rs
@@ -1,3 +1,4 @@
+use crate::OptionalPlugin;
 use bevy::asset::Handle;
 use bevy::prelude::*;
 use bevy::render::render_resource::{
@@ -18,13 +19,8 @@ pub struct MinimapPlugin;
 
 impl Plugin for MinimapPlugin {
     fn build(&self, app: &mut App) {
-        if !app.is_plugin_added::<EguiPlugin>() {
-            println!("Adding EguiPlugin {}", app.is_plugin_added::<EguiPlugin>());
-            app.add_plugins(EguiPlugin);
-            println!("Added EguiPlugin {}", app.is_plugin_added::<EguiPlugin>());
-        }
-
-        app.init_resource::<Minimap>()
+        app.add_optional_plugin(EguiPlugin)
+            .init_resource::<Minimap>()
             .add_systems(Startup, setup_default_texture)
             .add_systems(Update, draw_minimap_window);
     }

--- a/ryot_compass/src/ryot_bevy/appearances.rs
+++ b/ryot_compass/src/ryot_bevy/appearances.rs
@@ -1,28 +1,17 @@
-use crate::LoadAssetCommand;
 use bevy::asset::io::Reader;
 use bevy::asset::{Asset, AssetLoader, AsyncReadExt, BoxedFuture, LoadContext};
 use bevy::prelude::*;
 use bevy::reflect::TypeUuid;
 use prost::Message;
 use ryot::appearances::Appearances;
-use std::marker::PhantomData;
 use thiserror::Error;
 
 pub struct AppearanceAssetPlugin;
 
-#[derive(Debug, Default, Resource)]
-pub struct AppearanceHandle {
-    pub handle: Handle<Appearance>,
-}
-
 impl Plugin for AppearanceAssetPlugin {
     fn build(&self, app: &mut App) {
         app.init_asset::<Appearance>()
-            .register_asset_loader(AppearanceAssetLoader {})
-            .init_resource::<AppearanceHandle>()
-            .add_event::<LoadAssetCommand<Appearance>>()
-            .add_systems(Startup, init_appearances)
-            .add_systems(Update, load_appearances);
+            .register_asset_loader(AppearanceAssetLoader {});
     }
 }
 
@@ -66,22 +55,5 @@ impl AssetLoader for AppearanceAssetLoader {
 
     fn extensions(&self) -> &[&str] {
         &["dat"]
-    }
-}
-
-pub fn init_appearances(mut event_writer: EventWriter<LoadAssetCommand<Appearance>>) {
-    event_writer.send(LoadAssetCommand {
-        path: "appearances.dat".to_string(),
-        _marker: PhantomData,
-    });
-}
-
-fn load_appearances(
-    asset_server: Res<AssetServer>,
-    mut appearance: ResMut<AppearanceHandle>,
-    mut reader: EventReader<LoadAssetCommand<Appearance>>,
-) {
-    for LoadAssetCommand { path, .. } in reader.read() {
-        appearance.handle = asset_server.load(path);
     }
 }

--- a/ryot_compass/src/ryot_bevy/configs.rs
+++ b/ryot_compass/src/ryot_bevy/configs.rs
@@ -1,9 +1,8 @@
 use bevy::prelude::*;
 use bevy_common_assets::toml::TomlAssetPlugin;
-use ryot::CONTENT_CONFIG_PATH;
+use ryot::ContentConfigs;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Deserializer};
-use std::any::type_name;
 use std::fmt::Debug;
 use std::marker::PhantomData;
 
@@ -25,11 +24,8 @@ pub trait Configurable: DeserializeOwned + Default + Clone + Send + Sync + 'stat
 
 impl<T: Configurable> Plugin for ConfigPlugin<T> {
     fn build(&self, app: &mut App) {
-        app.add_event::<LoadConfigCommand<T>>()
-            .init_resource::<ConfigHandle<T>>()
-            .init_asset::<ConfigAsset<T>>()
-            .add_plugins(TomlAssetPlugin::<ConfigAsset<T>>::new(&T::extensions()))
-            .add_systems(Update, load_config::<T>);
+        app.init_asset::<ConfigAsset<T>>()
+            .add_plugins(TomlAssetPlugin::<ConfigAsset<T>>::new(&T::extensions()));
     }
 }
 
@@ -60,6 +56,12 @@ impl<'a, T: Configurable> DefaultConfig<'a, T> for Option<&'a ConfigAsset<T>> {
     }
 }
 
+impl Configurable for ContentConfigs {
+    fn extensions() -> Vec<&'static str> {
+        vec!["content.toml"]
+    }
+}
+
 impl<T: Configurable> TypePath for ConfigAsset<T> {
     fn type_path() -> &'static str {
         "configs::ConfigWrapper<T>"
@@ -67,146 +69,5 @@ impl<T: Configurable> TypePath for ConfigAsset<T> {
 
     fn short_type_path() -> &'static str {
         "ConfigWrapper<T>"
-    }
-}
-
-#[derive(Resource, Clone, Debug, Default)]
-pub struct ConfigHandle<T: Configurable> {
-    pub source: Option<String>,
-    pub handle: Handle<ConfigAsset<T>>,
-}
-
-#[derive(Debug, Clone, Event)]
-pub struct LoadConfigCommand<T> {
-    loading_type: LoadingType<T>,
-    _marker: PhantomData<T>,
-}
-
-impl<T> LoadConfigCommand<T> {
-    pub fn reload() -> Self {
-        Self {
-            loading_type: LoadingType::Reload,
-            _marker: PhantomData,
-        }
-    }
-
-    pub fn load(new_file: String) -> Self {
-        Self {
-            loading_type: LoadingType::Load(new_file),
-            _marker: PhantomData,
-        }
-    }
-
-    pub fn update(new_config: T) -> Self {
-        Self {
-            loading_type: LoadingType::Update(new_config),
-            _marker: PhantomData,
-        }
-    }
-}
-
-#[derive(Debug, Clone)]
-pub enum LoadingType<T> {
-    Reload,
-    Load(String),
-    Update(T),
-}
-
-impl<T> Default for LoadConfigCommand<T> {
-    fn default() -> Self {
-        Self {
-            loading_type: LoadingType::Reload,
-            _marker: PhantomData,
-        }
-    }
-}
-
-pub trait ConfigApp {
-    fn add_config<T: Configurable>(&mut self, config_path: &str) -> &mut Self;
-}
-
-impl ConfigApp for App {
-    fn add_config<T: Configurable>(&mut self, config_path: &str) -> &mut Self {
-        assert!(
-            !self.is_plugin_added::<ConfigPlugin<T>>(),
-            "This config is already initialized",
-        );
-
-        self.add_plugins(ConfigPlugin::<T> {
-            _marker: PhantomData,
-        });
-
-        let handle: Handle<ConfigAsset<T>> = self
-            .world
-            .get_resource::<AssetServer>()
-            .unwrap()
-            .load(config_path.to_string());
-
-        self.insert_resource(ConfigHandle {
-            source: Some(config_path.to_string()),
-            handle,
-        })
-    }
-}
-
-fn load_config<T: Configurable>(
-    asset_server: Res<AssetServer>,
-    mut config: ResMut<ConfigHandle<T>>,
-    mut configs: ResMut<Assets<ConfigAsset<T>>>,
-    mut reader: EventReader<LoadConfigCommand<T>>,
-) {
-    for LoadConfigCommand { loading_type, .. } in reader.read() {
-        match loading_type {
-            LoadingType::Reload => {
-                let Some(source) = &config.source else {
-                    warn!(
-                        "Trying to reload config for '{}', but no config file is configured",
-                        type_name::<T>()
-                    );
-                    return;
-                };
-
-                config.handle = asset_server.load(source);
-                debug!("Reloaded config '{}'", type_name::<T>());
-            }
-            LoadingType::Load(new_file) => {
-                config.source = Some(new_file.clone());
-                config.handle = asset_server.load(new_file.clone());
-                debug!("Loading config '{}' from '{}'", type_name::<T>(), new_file);
-            }
-            LoadingType::Update(new_config) => {
-                config.source = None;
-                config.handle = configs.add(ConfigAsset(new_config.clone()));
-                debug!("Setting config '{}' dynamically", type_name::<T>());
-            }
-        }
-    }
-}
-
-pub fn print_config_system<T: Configurable + Debug>(
-    config: Res<ConfigHandle<T>>,
-    configs: Res<Assets<ConfigAsset<T>>>,
-) {
-    if let Some(config) = configs.get(config.handle.id()) {
-        debug!("Config '{}': {:?}", type_name::<T>(), config);
-    }
-}
-
-pub fn test_reload_config<T: Configurable>(
-    keyboard_input: Res<Input<KeyCode>>,
-    mut writer: EventWriter<LoadConfigCommand<T>>,
-) {
-    if keyboard_input.just_pressed(KeyCode::R) {
-        writer.send(LoadConfigCommand::<T>::reload());
-    }
-
-    if keyboard_input.just_pressed(KeyCode::L) {
-        writer.send(LoadConfigCommand::<T>::load(
-            CONTENT_CONFIG_PATH.to_string(),
-        ));
-    }
-
-    if keyboard_input.just_pressed(KeyCode::N) {
-        writer.send(LoadConfigCommand::<T>::update(T::default()));
     }
 }

--- a/ryot_compass/src/ryot_bevy/content.rs
+++ b/ryot_compass/src/ryot_bevy/content.rs
@@ -1,106 +1,72 @@
-use crate::{AsyncEventApp, ConfigAsset, ConfigHandle, Configurable, LoadAssetCommand};
-use bevy::asset::Assets;
+use crate::{AppStates, Appearance, AppearanceAssetPlugin, ConfigAsset, ConfigPlugin};
 use bevy::prelude::*;
+use bevy_asset_loader::prelude::*;
 use bevy_common_assets::json::JsonAssetPlugin;
 use ryot::appearances::{ContentType, SpriteSheetSet};
 use ryot::ContentConfigs;
-use std::marker::PhantomData;
 
 pub struct ContentPlugin;
 
 impl Plugin for ContentPlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<Sprites>()
-            .add_event::<LoadAssetCommand<Content>>()
-            .add_async_event::<ContentWasLoaded>()
-            .add_plugins(JsonAssetPlugin::<Content>::new(&["json"]))
-            .add_systems(Startup, init_content)
-            .add_systems(Update, load_content)
-            .add_systems(Update, handle_content_loaded);
-    }
-}
+            .add_plugins(JsonAssetPlugin::<Catalog>::new(&["json"]));
 
-impl Configurable for ContentConfigs {
-    fn extensions() -> Vec<&'static str> {
-        vec!["content.toml"]
+        app.add_plugins(AppearanceAssetPlugin)
+            .add_plugins(ConfigPlugin::<ContentConfigs>::default());
+
+        app.add_loading_state(
+            LoadingState::new(AppStates::LoadingContent)
+                .continue_to_state(AppStates::PreparingContent)
+                .load_collection::<ContentAssets>(),
+        )
+        .add_systems(OnEnter(AppStates::PreparingContent), prepare_content);
     }
 }
 
 #[derive(Resource, Debug, Default)]
 pub struct Sprites {
     pub sheets: Option<SpriteSheetSet>,
-    pub content_handle: Handle<Content>,
 }
 
 #[derive(serde::Deserialize, Asset, TypePath)]
 #[serde(transparent)]
-pub struct Content {
+pub struct Catalog {
     pub content: Vec<ContentType>,
 }
 
-#[derive(Event, Debug, Clone, Default)]
-pub struct ContentWasLoaded {
-    pub file_name: String,
-    pub content: Vec<ContentType>,
+#[derive(AssetCollection, Resource)]
+pub struct ContentAssets {
+    #[asset(path = "appearances.dat")]
+    pub appearances: Handle<Appearance>,
+    #[asset(path = "catalog-content.json")]
+    pub catalog_content: Handle<Catalog>,
+    #[asset(path = "config/.content.toml")]
+    pub config: Handle<ConfigAsset<ContentConfigs>>,
 }
 
-impl ContentWasLoaded {
-    pub fn from_bytes(file_name: String, bytes: Vec<u8>) -> Option<Self> {
-        if let Ok(content) = serde_json::from_slice::<Vec<ContentType>>(&bytes) {
-            Some(Self { file_name, content })
-        } else {
-            None
-        }
-    }
-}
-
-pub fn init_content(mut event_writer: EventWriter<LoadAssetCommand<Content>>) {
-    event_writer.send(LoadAssetCommand {
-        path: "catalog-content.json".to_string(),
-        _marker: PhantomData,
-    });
-}
-
-pub fn load_content(
-    asset_server: Res<AssetServer>,
-    mut sprites: ResMut<Sprites>,
-    mut reader: EventReader<LoadAssetCommand<Content>>,
-) {
-    for LoadAssetCommand { path, .. } in reader.read() {
-        sprites.content_handle = asset_server.load::<Content>(path.clone());
-    }
-}
-
-fn handle_content_loaded(
-    contents: ResMut<Assets<Content>>,
-    config: Res<ConfigHandle<ContentConfigs>>,
+fn prepare_content(
+    contents: Res<Assets<Catalog>>,
+    static_assets: Res<ContentAssets>,
     configs: Res<Assets<ConfigAsset<ContentConfigs>>>,
     mut sprites: ResMut<Sprites>,
-    mut ev_asset: EventReader<AssetEvent<Content>>,
-    mut ev_content: EventReader<ContentWasLoaded>,
+    mut state: ResMut<NextState<AppStates>>,
 ) {
-    let Some(ConfigAsset(config)) = configs.get(config.handle.id()) else {
-        warn!("No config found for content");
-        return;
+    info!("Preparing content");
+    let Some(ConfigAsset(configs)) = configs.get(static_assets.config.id()) else {
+        panic!("No config found for content");
     };
 
-    let mut update_sheets = |content: &[ContentType]| {
-        sprites.sheets = Some(SpriteSheetSet::from_content(content, &config.sprite_sheet));
+    let Some(catalog) = contents.get(static_assets.catalog_content.id()) else {
+        panic!("No catalog loaded");
     };
 
-    for event in ev_content.read() {
-        debug!("Handling loaded content from file: {:?}", event.file_name);
-        update_sheets(&event.content);
-    }
+    sprites.sheets = Some(SpriteSheetSet::from_content(
+        &catalog.content,
+        &configs.sprite_sheet,
+    ));
 
-    for event in ev_asset.read() {
-        debug!("Handling asset event for content: {:?}", event);
-        let AssetEvent::LoadedWithDependencies { id } = event else {
-            continue;
-        };
+    state.set(AppStates::LoadingSprites);
 
-        if let Some(content) = contents.get(*id) {
-            update_sheets(&content.content);
-        }
-    }
+    info!("Finished preparing content");
 }

--- a/ryot_compass/src/ryot_bevy/mod.rs
+++ b/ryot_compass/src/ryot_bevy/mod.rs
@@ -7,7 +7,8 @@ pub use async_events::*;
 mod configs;
 pub use configs::*;
 
-pub mod content;
+mod content;
+pub use content::*;
 
 pub mod sprites;
 

--- a/ryot_compass/src/ryot_bevy/tests/configs.rs
+++ b/ryot_compass/src/ryot_bevy/tests/configs.rs
@@ -1,6 +1,6 @@
 use super::super::*;
 use bevy::prelude::*;
-use rstest::{fixture, rstest};
+use rstest::fixture;
 use serde::Deserialize;
 
 #[derive(Default, Deserialize, Clone, Debug)]
@@ -12,102 +12,6 @@ impl Configurable for TestConfig {
     fn extensions() -> Vec<&'static str> {
         vec!["test.toml"]
     }
-}
-
-#[rstest]
-fn test_plugin_setup(#[from(get_test_config_app)] app: App) {
-    let result = (|| -> Option<()> {
-        let config_asset = get_test_config_handle(&app)?;
-        assert_eq!(config_asset.source, None);
-
-        Some(())
-    })();
-
-    assert_eq!(result, Some(()));
-}
-
-#[rstest]
-fn test_load_config_dynamically(#[from(get_test_config_app)] mut app: App) {
-    let result = (|| -> Option<()> {
-        app.world
-            .resource_mut::<Events<LoadConfigCommand<TestConfig>>>()
-            .send(LoadConfigCommand::update(TestConfig {
-                test: "test".to_string(),
-            }));
-
-        app.update();
-
-        let config_asset = get_test_config_handle(&app)?;
-
-        assert_eq!(config_asset.source, None);
-        assert_eq!(get_test_config(&app)?.0.test, "test".to_string());
-
-        Some(())
-    })();
-
-    assert_eq!(result, Some(()));
-}
-
-#[rstest]
-fn test_load_config_from_file(#[from(get_test_config_app)] mut app: App) {
-    let result = (|| -> Option<()> {
-        app.add_plugins(TaskPoolPlugin::default());
-        app.world
-            .resource_mut::<Events<LoadConfigCommand<TestConfig>>>()
-            .send(LoadConfigCommand::load("fixtures/.test.toml".to_string()));
-
-        app.update();
-
-        let config_asset = get_test_config_handle(&app)?;
-        assert_eq!(config_asset.source, Some("fixtures/.test.toml".to_string()));
-
-        Some(())
-    })();
-
-    assert_eq!(result, Some(()));
-}
-
-#[rstest]
-fn test_reload_config(#[from(get_test_config_app)] mut app: App) {
-    let result = (|| -> Option<()> {
-        app.add_plugins(TaskPoolPlugin::default());
-        app.world
-            .resource_mut::<Events<LoadConfigCommand<TestConfig>>>()
-            .send(LoadConfigCommand::load("fixtures/.test.toml".to_string()));
-
-        app.update();
-
-        let config_asset = get_test_config_handle(&app)?;
-        assert_eq!(config_asset.source, Some("fixtures/.test.toml".to_string()));
-
-        app.world
-            .resource_mut::<Events<LoadConfigCommand<TestConfig>>>()
-            .send(LoadConfigCommand::reload());
-
-        app.update();
-
-        let config_asset = get_test_config_handle(&app)?;
-        assert_eq!(config_asset.source, Some("fixtures/.test.toml".to_string()));
-
-        Some(())
-    })();
-
-    assert_eq!(result, Some(()));
-}
-
-fn get_test_config_handle(app: &App) -> Option<&ConfigHandle<TestConfig>> {
-    app.world.get_resource::<ConfigHandle<TestConfig>>()
-}
-
-fn get_test_config(app: &App) -> Option<&ConfigAsset<TestConfig>> {
-    app.world
-        .get_resource::<Assets<ConfigAsset<TestConfig>>>()?
-        .get(
-            app.world
-                .get_resource::<ConfigHandle<TestConfig>>()?
-                .handle
-                .id(),
-        )
 }
 
 #[fixture]


### PR DESCRIPTION
## Why?
Asset loading is a complex matter. Because it happens async via bevy assert server, we need to have good control over the availability of the loaded assets. [bevy_asset_loader](https://github.com/NiklasEi/bevy_asset_loader) simplifies that for us, providing multiple features when it comes to asset loading: dynamic loading, folder loading, macros, etc.

## What?
Currently we have a few types of assets being used in Compass:
- .dat appearances
- .json catalog
- .content.toml config
- .png images/sprites (in our case, most of them are atlases)

While the first three are trivial and can be easily ported to assets loader crate, the images are a bit more convoluted. To reduce the costs of dealing with thousand of sprites, we use sprite atlases. Although asset loader deals well with atlases, it does increase the loading time and the overall memory usage.

To balance that, we are adding sprites pre-loading as optional behind a feature, while keeping our lazy-loaded sprites as the default.