### PR TITLE
Lucas/ryo 33 move drawing behind leafwing inputs

### DIFF
--- a/ryot/Cargo.toml
+++ b/ryot/Cargo.toml
@@ -41,6 +41,7 @@ color-eyre = "0.6.2"
 prost = "0.12.3"
 prost-types = "0.12.3"
 
+leafwing-input-manager = { version = "0.11.2", optional = true }
 bevy_common_assets = { version = "0.9.0", features = ["toml", "json"], optional = true }
 bevy_asset_loader = { version = "0.19.1", features = ["2d"], optional = true }
 [dependencies.bevy]
@@ -80,7 +81,7 @@ rstest = "0.18.2"
 default = ["compression", "bevy"]
 lmdb = ["dep:heed", "dep:postcard"]
 compression = ["dep:zstd"]
-bevy = ["dep:bevy", "dep:bevy_common_assets", "dep:bevy_asset_loader"]
+bevy = ["dep:bevy", "dep:bevy_common_assets", "dep:bevy_asset_loader", "dep:leafwing-input-manager"]
 
 [lints.clippy]
 enum_glob_use = "deny"

--- a/ryot/src/bevy_ryot/mod.rs
+++ b/ryot/src/bevy_ryot/mod.rs
@@ -31,6 +31,7 @@ use bevy_asset_loader::asset_collection::AssetCollection;
 use bevy_asset_loader::loading_state::{LoadingState, LoadingStateAppExt};
 use bevy_asset_loader::prelude::*;
 use bevy_common_assets::json::JsonAssetPlugin;
+use leafwing_input_manager::prelude::*;
 
 pub static RYOT_ANCHOR: Anchor = Anchor::BottomRight;
 pub static GRID_LAYER: Layer = Layer::Custom(998);
@@ -297,5 +298,20 @@ pub fn spawn_grid(
             material: materials.add(ColorMaterial::default()),
             ..default()
         });
+    }
+}
+
+/// A helper for leafwing-input-manager that checks if an action happened based on
+/// long-press triggers. If you have a long press trigger, then it checks for pressed,
+/// otherwise it checks for just_pressed.
+pub fn check_action<A: Actionlike>(
+    action: A,
+    long_press_triggered: bool,
+    action_state: &ActionState<A>,
+) -> bool {
+    if long_press_triggered {
+        action_state.pressed(action)
+    } else {
+        action_state.just_pressed(action)
     }
 }

--- a/ryot_compass/Cargo.toml
+++ b/ryot_compass/Cargo.toml
@@ -42,6 +42,7 @@ rstest = "0.18.2"
 bevy_pancam = { version = "0.10.0", features = [
     "bevy_egui",
 ], git = "https://github.com/luan/bevy_pancam", branch = "luan/modifier-keys" }
+leafwing-input-manager = "0.11.2"
 
 [dependencies.bevy]
 version = "0.12.1"

--- a/ryot_compass/src/bevy_compass/drawing.rs
+++ b/ryot_compass/src/bevy_compass/drawing.rs
@@ -1,8 +1,9 @@
 use crate::{gui_is_not_in_use, Cursor};
 use bevy::app::{App, Plugin, Update};
 use bevy::ecs::system::EntityCommand;
-use bevy::input::Input;
 use bevy::prelude::*;
+use leafwing_input_manager::prelude::*;
+use leafwing_input_manager::user_input::InputKind;
 use rand::prelude::SliceRandom;
 use rand::thread_rng;
 use ryot::bevy_ryot::drawing::{
@@ -12,6 +13,45 @@ use ryot::bevy_ryot::*;
 use ryot::position::TilePosition;
 use std::hash::Hash;
 use std::marker::PhantomData;
+
+#[derive(Actionlike, Reflect, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum DrawingAction {
+    Stop,
+    Draw,
+    Erase,
+    Undo,
+    Redo,
+}
+
+impl DrawingAction {
+    pub fn get_default_input_map() -> InputMap<DrawingAction> {
+        let mut input_map = InputMap::new([
+            (MouseButton::Left, DrawingAction::Draw),
+            (MouseButton::Right, DrawingAction::Erase),
+        ]);
+
+        input_map.insert_chord([KeyCode::ControlLeft, KeyCode::Z], DrawingAction::Undo);
+        input_map.insert_chord([KeyCode::ControlLeft, KeyCode::R], DrawingAction::Redo);
+
+        // Small hack to remove clash with the pancam plugin
+        input_map.insert_chord(
+            [
+                InputKind::Mouse(MouseButton::Left),
+                InputKind::Keyboard(KeyCode::AltLeft),
+            ],
+            DrawingAction::Stop,
+        );
+        input_map.insert_chord(
+            [
+                InputKind::Mouse(MouseButton::Left),
+                InputKind::Keyboard(KeyCode::AltRight),
+            ],
+            DrawingAction::Stop,
+        );
+
+        input_map
+    }
+}
 
 /// This resource is used to configure the undo/redo system.
 /// Currently, it only contains a timer that is used to control the speed of the undo/redo actions.
@@ -49,10 +89,11 @@ impl<C: ContentAssets> Default for DrawingPlugin<C> {
 
 impl<C: ContentAssets> Plugin for DrawingPlugin<C> {
     fn build(&self, app: &mut App) {
-        app.add_plugins(drawing::DrawingPlugin)
-            .init_resource::<UndoRedoConfig>()
+        app.init_resource::<UndoRedoConfig>()
             .init_resource::<CommandHistory>()
             .init_resource::<MapTiles>()
+            .add_plugins(drawing::DrawingPlugin)
+            .add_plugins(InputManagerPlugin::<DrawingAction>::default())
             .add_systems(
                 Update,
                 (
@@ -77,15 +118,17 @@ fn delete_tile_content(
     tiles: ResMut<MapTiles>,
     mut command_history: ResMut<CommandHistory>,
     current_appearance_query: Query<(&mut AppearanceDescriptor, &Visibility), Without<Cursor>>,
-    mouse_button_input: Res<Input<MouseButton>>,
-    cursor_query: Query<(&TilePosition, Changed<TilePosition>), With<Cursor>>,
+    cursor_query: Query<
+        (
+            &ActionState<DrawingAction>,
+            &TilePosition,
+            Changed<TilePosition>,
+        ),
+        With<Cursor>,
+    >,
 ) {
-    for (tile_pos, position_changed) in &cursor_query {
-        if !should_react_to_input::<MouseButton>(
-            position_changed,
-            MouseButton::Right,
-            &mouse_button_input,
-        ) {
+    for (action_state, tile_pos, position_changed) in &cursor_query {
+        if !check_action(DrawingAction::Erase, position_changed, action_state) {
             return;
         }
 
@@ -132,29 +175,27 @@ fn undo_redo_tile_action(
     time: Res<Time>,
     mut commands: Commands,
     tiles: ResMut<MapTiles>,
-    keyboard_input: Res<Input<KeyCode>>,
     mut undo_redo_config: ResMut<UndoRedoConfig>,
     mut command_history: ResMut<CommandHistory>,
+    action_state_query: Query<&ActionState<DrawingAction>, With<Cursor>>,
 ) {
     undo_redo_config.timer.tick(time.delta());
 
-    let mut actions: [(
-        KeyCode,
-        fn(&mut Commands, &ResMut<MapTiles>, &mut ResMut<CommandHistory>),
-    ); 2] = [(KeyCode::U, undo), (KeyCode::R, redo)];
-
+    let action_state = action_state_query.single();
+    let mut actions = [DrawingAction::Undo, DrawingAction::Redo];
     actions.shuffle(&mut thread_rng());
 
-    for &(key_code, action) in actions.iter() {
-        react_to_input(
-            key_code,
-            action,
-            &mut undo_redo_config.timer,
-            &keyboard_input,
-            &mut commands,
-            &tiles,
-            &mut command_history,
-        );
+    for action in actions {
+        let is_timer_finished = undo_redo_config.timer.just_finished();
+
+        if check_action(action, is_timer_finished, action_state) {
+            undo_redo_config.timer.reset();
+            match action {
+                DrawingAction::Undo => undo(&mut commands, &tiles, &mut command_history),
+                DrawingAction::Redo => redo(&mut commands, &tiles, &mut command_history),
+                _ => (),
+            }
+        }
     }
 }
 
@@ -164,18 +205,31 @@ fn draw_to_tile<C: ContentAssets>(
     mut command_history: ResMut<CommandHistory>,
     content_assets: Res<C>,
     current_appearance_query: Query<(&mut AppearanceDescriptor, &Visibility), Without<Cursor>>,
-    mouse_button_input: Res<Input<MouseButton>>,
-    cursor_query: Query<
-        (&AppearanceDescriptor, &TilePosition, Changed<TilePosition>),
-        With<Cursor>,
-    >,
+    cursor_query: Query<(
+        &ActionState<DrawingAction>,
+        &AppearanceDescriptor,
+        &TilePosition,
+        &Cursor,
+        Changed<TilePosition>,
+    )>,
 ) {
     if content_assets.sprite_sheet_data_set().is_none() {
         warn!("Trying to draw a sprite without any loaded content");
         return;
     };
 
-    for (AppearanceDescriptor { group, id, .. }, tile_pos, position_changed) in &cursor_query {
+    for (
+        action_state,
+        AppearanceDescriptor { group, id, .. },
+        tile_pos,
+        cursor,
+        position_changed,
+    ) in &cursor_query
+    {
+        if !cursor.drawing_state.enabled {
+            continue;
+        }
+
         let Some(prepared_appearance) = content_assets
             .prepared_appearances()
             .get_for_group(*group, *id)
@@ -183,11 +237,7 @@ fn draw_to_tile<C: ContentAssets>(
             return;
         };
 
-        if !should_react_to_input::<MouseButton>(
-            position_changed,
-            MouseButton::Left,
-            &mouse_button_input,
-        ) {
+        if !check_action(DrawingAction::Draw, position_changed, action_state) {
             return;
         }
 
@@ -226,18 +276,6 @@ fn draw_to_tile<C: ContentAssets>(
     }
 }
 
-fn should_react_to_input<T: Copy + Eq + Hash + Send + Sync + 'static>(
-    triggered: bool,
-    desired_input: T,
-    input_resource: &Res<Input<T>>,
-) -> bool {
-    if input_resource.just_pressed(desired_input) {
-        return true;
-    }
-
-    triggered && input_resource.pressed(desired_input)
-}
-
 fn redo(
     commands: &mut Commands,
     tiles: &ResMut<MapTiles>,
@@ -274,19 +312,4 @@ fn get_entity_from_command_record(
         .get(&command_record.tile_pos)
         .and_then(|t| t.get(&command_record.layer))
         .copied()
-}
-
-fn react_to_input<T: Copy + Eq + Hash + Send + Sync + 'static>(
-    desired_input: T,
-    block: fn(&mut Commands, &ResMut<MapTiles>, &mut ResMut<CommandHistory>),
-    timer: &mut Timer,
-    keyboard_input: &Res<Input<T>>,
-    commands: &mut Commands,
-    tiles: &ResMut<MapTiles>,
-    command_history: &mut ResMut<CommandHistory>,
-) {
-    if should_react_to_input::<T>(timer.just_finished(), desired_input, keyboard_input) {
-        timer.reset();
-        block(commands, tiles, command_history);
-    }
 }

--- a/ryot_compass/src/bevy_compass/gui.rs
+++ b/ryot_compass/src/bevy_compass/gui.rs
@@ -4,7 +4,7 @@ use bevy_egui::EguiContexts;
 /// The GUIState resource is used to keep track of whether the GUI is being used.
 /// This is useful for systems that should only run when the GUI is/is not being used.
 /// For example, drawing systems should only run when the GUI is not being used.
-#[derive(Resource, Default)]
+#[derive(Resource, PartialEq, Eq, Default)]
 pub struct GUIState {
     pub is_being_used: bool,
 }
@@ -47,5 +47,5 @@ pub fn gui_is_not_in_use() -> impl FnMut(Res<GUIState>) -> bool + Clone {
 
 /// This system updates the GUIState resource to indicate whether EGUI is being used or not.
 pub fn check_egui_usage(egui: EguiContexts, mut gui_state: ResMut<GUIState>) {
-    gui_state.is_being_used = egui.ctx().is_pointer_over_area()
+    gui_state.is_being_used = egui.ctx().wants_pointer_input() || egui.ctx().wants_keyboard_input()
 }

--- a/ryot_compass/src/main.rs
+++ b/ryot_compass/src/main.rs
@@ -230,7 +230,7 @@ impl<C: ContentAssets> Plugin for UIPlugin<C> {
     fn build(&self, app: &mut App) {
         app.add_optional_plugin(EguiPlugin)
             .init_resource::<GUIState>()
-            .add_systems(First, check_egui_usage)
+            .add_systems(PostUpdate, check_egui_usage)
             .init_resource::<AboutMeOpened>()
             .add_systems(
                 Update,


### PR DESCRIPTION
We want better input management as we move forward, and [leafwing](https://github.com/Leafwing-Studios/leafwing-input-manager) solution is already a full bevy compatible way of dealing with inputs, with multiple features.

So, we moved our drawing inputs to use [leafwing inputs](https://github.com/Leafwing-Studios/leafwing-input-manager) instead of raw inputs.