### PR TITLE
Lucas/fix undo redo for drawing

### DIFF
--- a/ryot/Cargo.toml
+++ b/ryot/Cargo.toml
@@ -42,7 +42,6 @@ thiserror.workspace = true
 time-test.workspace = true
 zstd = { workspace = true, optional = true }
 async-std = "1.12.0"
-anyhow = { version = "1.0.77", features = [] }
 
 [dev-dependencies]
 rstest.workspace = true

--- a/ryot/src/bevy_ryot/drawing/commands/load.rs
+++ b/ryot/src/bevy_ryot/drawing/commands/load.rs
@@ -19,6 +19,12 @@ impl LoadTileContent {
     }
 }
 
+impl From<LoadTileContent> for CommandState {
+    fn from(_: LoadTileContent) -> Self {
+        CommandState::default().persist()
+    }
+}
+
 impl Command for LoadTileContent {
     fn apply(self, world: &mut World) {
         for info in self.0.iter() {
@@ -26,7 +32,7 @@ impl Command for LoadTileContent {
                 world,
                 *info,
                 (info.0, info.1, info.2, None),
-                CommandState::from_load(),
+                self.clone().into(),
             );
         }
     }

--- a/ryot/src/bevy_ryot/drawing/commands/mod.rs
+++ b/ryot/src/bevy_ryot/drawing/commands/mod.rs
@@ -39,13 +39,14 @@ pub struct CommandState {
 }
 
 impl CommandState {
-    /// When loading from the persistence layer, we don't want to save the changes again,
-    /// so we set the persisted flag to true, so that persistence is ignored during loading.
-    pub fn from_load() -> Self {
-        Self {
-            applied: false,
-            persisted: true,
-        }
+    pub fn apply(mut self) -> Self {
+        self.applied = true;
+        self
+    }
+
+    pub fn persist(mut self) -> Self {
+        self.persisted = true;
+        self
     }
 }
 

--- a/ryot/src/bevy_ryot/map.rs
+++ b/ryot/src/bevy_ryot/map.rs
@@ -151,7 +151,7 @@ impl MapTile {
 
     fn pop_bottom(&mut self, relative_layer: RelativeLayer) -> Option<Entity> {
         self.bottom.get_mut(&relative_layer).and_then(|entities| {
-            let last = entities.iter().last()?.0.clone();
+            let last = *entities.iter().last()?.0;
             entities.remove(&last)
         })
     }
@@ -173,7 +173,7 @@ impl MapTile {
         self.bottom
             .get(&relative_layer)
             .and_then(|entities| entities.get(order))
-            .map(|entity| *entity)
+            .copied()
     }
 
     fn push_bottom(&mut self, bottom_layer: BottomLayer, entity: Entity) {
@@ -302,14 +302,14 @@ mod test {
         assert_eq!(
             iter.next_back(),
             Some((
-                Layer::Bottom(BottomLayer::new(2, RelativeLayer::Creature)),
+                Layer::Bottom(BottomLayer::new(10, RelativeLayer::Creature)),
                 Entity::from_raw(0)
             ))
         );
         assert_eq!(
             iter.next_back(),
             Some((
-                Layer::Bottom(BottomLayer::new(1, RelativeLayer::Creature)),
+                Layer::Bottom(BottomLayer::new(4, RelativeLayer::Creature)),
                 Entity::from_raw(0)
             ))
         );


### PR DESCRIPTION
In a same UpdateTileContent command, the old and new info should always
target the same layer. They shouldn't ever point to different layers.

In a bottom layer, if we are drawing in the next slot in the stack, the
old info should point to this slot with an empty appearance, because a
revert in this case is just a deletion of that layer.