### PR TITLE
chore: set default toolchain to nightly

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly"


### PR DESCRIPTION
set default toolchain to nightly since it is required for the use of unstable features