### PR TITLE
Async events improve

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2048,9 +2048,9 @@ checksum = "7059fff8937831a9ae6f0fe4d658ffabf58f2ca96aa9dec1c889f936f705f216"
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.11"
+version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "176dc175b78f56c0f321911d9c8eb2b77a78a4860b9c19db83835fea1a46649b"
+checksum = "ab3db02a9c5b5121e1e42fbdb1aeb65f5e02624cc58c43f2884c6ccac0b82f95"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -5031,6 +5031,7 @@ dependencies = [
  "bevy_common_assets",
  "bytes",
  "color-eyre",
+ "crossbeam-channel",
  "derive_more",
  "egui",
  "glam",

--- a/ryot/Cargo.toml
+++ b/ryot/Cargo.toml
@@ -16,6 +16,7 @@ readme = "../README.md"
 async-std = "1.12.0"
 derive_more = "0.99.17"
 serde_repr = "0.1"
+crossbeam-channel = "0.5.12"
 
 bevy = { workspace = true, optional = true }
 bevy_asset_loader = { workspace = true, optional = true }
@@ -54,10 +55,10 @@ default = ["bevy"]
 lmdb = ["dep:heed", "dep:postcard"]
 compression = ["dep:zstd"]
 bevy = [
-    "dep:bevy",
-    "dep:bevy_common_assets",
-    "dep:bevy_asset_loader",
-    "dep:leafwing-input-manager",
+	"dep:bevy",
+	"dep:bevy_common_assets",
+	"dep:bevy_asset_loader",
+	"dep:leafwing-input-manager",
 ]
 egui = ["dep:egui"]
 

--- a/ryot/src/bevy_ryot/async_events.rs
+++ b/ryot/src/bevy_ryot/async_events.rs
@@ -8,14 +8,12 @@ use bevy::prelude::*;
 use crossbeam_channel::{Receiver, Sender};
 
 // TODO: doc.
-#[derive(SystemSet, Default)]
+#[derive(SystemSet)]
 pub struct AsyncEventSet<T: Event>(PhantomData<T>);
 
 impl<T: Event> std::fmt::Debug for AsyncEventSet<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_tuple("AsyncEventSet")
-            .field(&format_args!("fn {}()", &std::any::type_name::<T>()))
-            .finish()
+        write!(f, "AsyncEventSet<{}>", &std::any::type_name::<T>())
     }
 }
 

--- a/ryot/src/bevy_ryot/async_events.rs
+++ b/ryot/src/bevy_ryot/async_events.rs
@@ -1,23 +1,57 @@
 //! This module provides a way to send events between systems asynchronously.
 //! It's useful to send events between threads that perform asynchronous tasks, such as loading
 //! content from disk or loading sprites from a sprite sheet before rendering.
+use std::{hash::Hasher, marker::PhantomData};
+
 use bevy::app::App;
 use bevy::prelude::*;
 use crossbeam_channel::{Receiver, Sender};
 
 // TODO: doc.
-#[derive(SystemSet, Clone, Copy, Eq, PartialEq, Hash, Debug)]
-pub struct AsyncEventSet<T>();
+#[derive(SystemSet, Default)]
+pub struct AsyncEventSet<T: Event>(PhantomData<T>);
+
+impl<T: Event> std::fmt::Debug for AsyncEventSet<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("AsyncEventSet")
+            .field(&format_args!("fn {}()", &std::any::type_name::<T>()))
+            .finish()
+    }
+}
+
+impl<T: Event> std::hash::Hash for AsyncEventSet<T> {
+    fn hash<H: Hasher>(&self, _state: &mut H) {
+        // all systems of a given type are the same
+    }
+}
+
+impl<T: Event> Clone for AsyncEventSet<T> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<T: Event> Copy for AsyncEventSet<T> {}
+
+impl<T: Event> PartialEq for AsyncEventSet<T> {
+    #[inline]
+    fn eq(&self, _other: &Self) -> bool {
+        // all systems of a given type are the same
+        true
+    }
+}
+
+impl<T: Event> Eq for AsyncEventSet<T> {}
 
 /// A resource that emits asynchronous events of a given type.
 /// It's a bevy friendly wrapper around a `crossbeam_channel::Sender`.
 #[derive(Resource, Deref, DerefMut)]
-pub struct AsyncEventSender<T>(pub Sender<T>);
+pub struct AsyncEventSender<T: Event>(pub Sender<T>);
 
 /// A resource that receives asynchronous events of a given type.
 /// It's a bevy friendly wrapper around a `crossbeam_channel::Receiver`.
 #[derive(Resource, Deref, DerefMut)]
-struct AsyncEventReceiver<T>(Receiver<T>);
+struct AsyncEventReceiver<T: Event>(Receiver<T>);
 
 /// A trait to add an asynchronous event to an App.
 pub trait AsyncEventApp {
@@ -35,17 +69,23 @@ impl AsyncEventApp for App {
 
         let (sender, receiver) = crossbeam_channel::unbounded::<T>();
 
-		self.add_event::<T>()
-            .add_systems(PreUpdate, unbounded_channel_to_event::<T>.in_set(AsyncEventSet<T>()))
+        self.add_event::<T>()
+            .add_systems(
+                PreUpdate,
+                unbounded_channel_to_event::<T>.in_set(AsyncEventSet::<T>(PhantomData)),
+            )
             .insert_resource(AsyncEventSender(sender))
             .insert_resource(AsyncEventReceiver(receiver));
 
-		self
+        self
     }
 }
 
 /// A system that sends events from the receiver to Bevy's event system.
 /// Converts the asynchronous event into a bevy event and sends it to the event system.
-fn unbounded_channel_to_event<T: Event>(receiver: Res<AsyncEventReceiver<T>>, mut writer: EventWriter<T>) {
+fn unbounded_channel_to_event<T: Event>(
+    receiver: Res<AsyncEventReceiver<T>>,
+    mut writer: EventWriter<T>,
+) {
     writer.send_batch(receiver.try_iter());
 }

--- a/ryot_compass/src/bevy_compass/gui.rs
+++ b/ryot_compass/src/bevy_compass/gui.rs
@@ -10,7 +10,7 @@ use crate::{ExportMap, LoadMap};
 #[cfg(not(target_arch = "wasm32"))]
 use bevy::app::AppExit;
 #[cfg(not(target_arch = "wasm32"))]
-use ryot::bevy_ryot::{AsyncEventApp, EventSender};
+use ryot::bevy_ryot::{AsyncEventApp, AsyncEventSender};
 
 use bevy::{prelude::*, render::camera::Viewport, winit::WinitWindows};
 use bevy_egui::{EguiContext, EguiContexts, EguiPlugin, EguiUserTextures};
@@ -81,7 +81,7 @@ fn ui_menu_system<C: ContentAssets>(
     #[cfg(not(target_arch = "wasm32"))] content_assets: Res<C>,
     #[cfg(not(target_arch = "wasm32"))] mut exit: EventWriter<AppExit>,
     #[cfg(not(target_arch = "wasm32"))] mut map_export_sender: EventWriter<ExportMap>,
-    #[cfg(not(target_arch = "wasm32"))] load_map_sender: Res<EventSender<LoadMap>>,
+    #[cfg(not(target_arch = "wasm32"))] load_map_sender: Res<AsyncEventSender<LoadMap>>,
     _windows: NonSend<WinitWindows>,
 ) {
     let Ok(mut cursor) = cursor_query.get_single_mut() else {


### PR DESCRIPTION
### Melhorias
- Prefira [crossbeam-channel](https://github.com/crossbeam-rs/crossbeam/tree/master/crossbeam-channel) ao invés de [std mpsc](https://doc.rust-lang.org/std/sync/mpsc/index.html).
- Renomeia `EventSender` para `AsyncEventSender` e `EventReceiver` para `AsyncEventReceiver`.
- Adiciona `AsyncEventSet`, possibilitando ordenar os sistemas.
- Renomeia `channel_to_event `para `unbounded_channel_to_event`.
- Prefira executar o mapeamento entre mensagem do canal para evento no Scheduler `PreUpdate` ao invés de `Update`.

Meu analyzer ta bugado com os 600 pacotes do projeto, além dos arquivos proto, pode ser que precise de algum polimento no código, além da doc do _SystemSet_.