### PR TITLE
impr: Point bevy_asset_loader to original repository

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -687,7 +687,7 @@ dependencies = [
 [[package]]
 name = "bevy_asset_loader"
 version = "0.20.0"
-source = "git+https://github.com/lgrossi/bevy_asset_loader?branch=lucas/set-of-dynamic-standard-assets#9888663bad4afce97f2fb630d6d7906c98a8a681"
+source = "git+https://github.com/NiklasEi/bevy_asset_loader?branch=main#fce89e2fdacecc09ed1e6b2bb3bdf2f9ba13fe00"
 dependencies = [
  "anyhow",
  "bevy",
@@ -700,7 +700,7 @@ dependencies = [
 [[package]]
 name = "bevy_asset_loader_derive"
 version = "0.20.0"
-source = "git+https://github.com/lgrossi/bevy_asset_loader?branch=lucas/set-of-dynamic-standard-assets#9888663bad4afce97f2fb630d6d7906c98a8a681"
+source = "git+https://github.com/NiklasEi/bevy_asset_loader?branch=main#fce89e2fdacecc09ed1e6b2bb3bdf2f9ba13fe00"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ debug = 0
 opt-level = 3
 
 [workspace.dependencies]
-bevy_asset_loader = { git = "https://github.com/lgrossi/bevy_asset_loader", branch = "lucas/set-of-dynamic-standard-assets", features = [
+bevy_asset_loader = { git = "https://github.com/NiklasEi/bevy_asset_loader", branch = "main", features = [
     "2d",
     "standard_dynamic_assets",
 ] }


### PR DESCRIPTION
With https://github.com/NiklasEi/bevy_asset_loader/pull/198 merged, we can now reference to the original [asset loader](https://github.com/NiklasEi/bevy_asset_loader) repository.

When a new release is generated we can then point to the latest version and remove the dependency on repository branches.